### PR TITLE
Fix import casing for case-sensitive filesystems

### DIFF
--- a/src/Compiler/CachingCompilerHost.ts
+++ b/src/Compiler/CachingCompilerHost.ts
@@ -4,7 +4,7 @@ import * as path from "path";
 import * as chokidar from "chokidar";
 
 import { Logger } from "../Reporting/Logger";
-import { TsCore } from "../Utils/tscore";
+import { TsCore } from "../Utils/TsCore";
 import { Utils } from "../Utils/Utilities";
 
 /**

--- a/src/Compiler/WatchCompilerHost.ts
+++ b/src/Compiler/WatchCompilerHost.ts
@@ -5,7 +5,7 @@ import * as chokidar from "chokidar";
 
 import { CachingCompilerHost } from "./CachingCompilerHost";
 import { Logger } from "../Reporting/Logger";
-import { TsCore } from "../Utils/tscore";
+import { TsCore } from "../Utils/TsCore";
 import { Utils } from "../Utils/Utilities";
 
 /**
@@ -32,13 +32,13 @@ export class WatchCompilerHost extends CachingCompilerHost {
             // Use program to get source files
             let sourceFile: TsCore.WatchedSourceFile = this.reuseableProgram.getSourceFile( fileName );
 
-            // If the source file has not been modified (it has a fs watcher ) then use it            
+            // If the source file has not been modified (it has a fs watcher ) then use it
             if ( sourceFile && sourceFile.fileWatcher ) {
                 //Logger.trace( "getSourceFile() watcher hit for: ", fileName );
                 return sourceFile;
             }
         }
-        
+
         // Use base class to get the source file
         //Logger.trace( "getSourceFile() reading source file from fs: ", fileName );
         let sourceFile: TsCore.WatchedSourceFile = super.getSourceFileImpl( fileName, languageVersion, onError );

--- a/src/Minifier/IdentifierSymbolInfo.ts
+++ b/src/Minifier/IdentifierSymbolInfo.ts
@@ -2,7 +2,7 @@
 import { Container } from "./ContainerContext";
 import { Ast } from "../Ast/Ast";
 import { Utils } from "../Utils/Utilities";
-import { Logger } from "../reporting/logger";
+import { Logger } from "../Reporting/Logger";
 
 export class IdentifierInfo {
 
@@ -76,7 +76,7 @@ export class IdentifierInfo {
             }
         }
 
-        return false;        
+        return false;
     }
 
     public isBlockScopedVariable(): boolean {
@@ -150,7 +150,7 @@ export class IdentifierInfo {
 
     public isPrivateMethod(): boolean {
         if ( ( this.symbol.flags & ts.SymbolFlags.Method ) > 0 ) {
-            
+
             // A method has a value declaration
             let flags = this.symbol.valueDeclaration.flags;
 
@@ -162,7 +162,7 @@ export class IdentifierInfo {
             let parent: ts.Symbol = ( <any>this.symbol ).parent;
 
             if ( parent && Ast.isClassInternal( parent ) ) {
-                
+
                 // TJT: Review - public methods of abstact classes are not shortened.
                 if ( !Ast.isClassAbstract( parent ) ) {
                     return true;
@@ -186,7 +186,7 @@ export class IdentifierInfo {
             let parent: ts.Symbol = ( <any>this.symbol ).parent;
 
             if ( parent && Ast.isClassInternal( parent ) ) {
-                
+
                 // TJT: Review - public properties of abstact classes are not shortened.
                 if ( !Ast.isClassAbstract( parent ) ) {
                     return true;

--- a/src/Project/ProjectBuildContext.ts
+++ b/src/Project/ProjectBuildContext.ts
@@ -4,7 +4,7 @@ import { Compiler } from "../Compiler/Compiler";
 import { ProjectConfig } from "../Project/ProjectConfig";
 import { WatchCompilerHost }  from "../Compiler/WatchCompilerHost";
 import { CompileStream }  from "../Compiler/CompileStream";
-import { TsCore } from "../Utils/tsCore";
+import { TsCore } from "../Utils/TsCore";
 import { Utils } from "../Utils/Utilities";
 
 export class ProjectBuildContext {
@@ -37,7 +37,7 @@ export class ProjectBuildContext {
 
             Utils.forEach( this.program.getSourceFiles(), sourceFile => {
 
-                // Remove fileWatcher from the outgoing program source files if they are not in the 
+                // Remove fileWatcher from the outgoing program source files if they are not in the
                 // new program source file set
 
                 if ( !( newSourceFiles && Utils.contains( newSourceFiles, sourceFile ) ) ) {


### PR DESCRIPTION
Running in OS X with a case-sensitive filesystem:

```
$ tsc --project src/tsconfig.json --noemit
src/Compiler/CachingCompilerHost.ts(7,24): error TS2307: Cannot find module '../Utils/tscore'.
src/Compiler/WatchCompilerHost.ts(8,24): error TS2307: Cannot find module '../Utils/tscore'.
src/Minifier/IdentifierSymbolInfo.ts(5,24): error TS2307: Cannot find module '../reporting/logger'.
src/Project/ProjectBuildContext.ts(7,24): error TS2307: Cannot find module '../Utils/tsCore'.
Files:              42
Lines:           36365
Nodes:          143981
Identifiers:     55181
Symbols:       1374511
Types:            9554
Memory used:    87578K
I/O read:        0.01s
I/O write:       0.00s
Parse time:      0.40s
Bind time:       0.28s
Check time:      0.99s
Emit time:       0.00s
Total time:      1.67s
```

This PR aligns imports with the exact casing of files.