### PR TITLE
Fix typings export and casing

### DIFF
--- a/TsProject.d.ts
+++ b/TsProject.d.ts
@@ -1,4 +1,5 @@
-import * as stream from "stream";
-export declare namespace TsProject {
-    function src(configFilePath: string, settings?: any): stream.Readable;
+declare namespace TsProject {
+    function src(configFilePath: string, settings?: any): NodeJS.ReadableStream;
 }
+
+export = TsProject;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://github.com/toddthomson/tsproject",
   "bugs": "https://github.com/toddthomson/tsproject/issues",
   "main": "./tsproject.min.js",
-  "typings": "./tsproject.d.ts",
+  "typings": "./TsProject.d.ts",
   "dependencies": {
     "chalk": "^1.1.1",
     "chokidar": "^1.4.2",


### PR DESCRIPTION
This PR:

1. Fixes the casing of the typings reference in `package.json`
2. Exports the namespace correctly
  - since the module is written in a CommonJS fashion, the `export =` syntax is necessary. The previous implementation essentially exported `require('tsproject').TsProject.src`